### PR TITLE
Feat: Add docker as a make target, and shrink resulting docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS BUILDER
 
 ENV DEBIAN_FRONTEND "noninteractive"
-RUN apt-get update && apt-get -y install build-essential libboost-iostreams-dev libboost-program-options-dev libz-dev
-RUN mkdir /trimmer
-
-COPY NSCtrim.cpp /trimmer
-COPY bounded_levenshtein_distance.cpp /trimmer
-COPY Makefile /trimmer
+# hadolint ignore=DL3009
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+    build-essential=12.8ubuntu1 \
+    libboost-iostreams-dev=1.71.0.0ubuntu2 \
+    libboost-program-options-dev=1.71.0.0ubuntu2 \
+    zlib1g-dev=1:1.2.11.dfsg-2ubuntu1.2
 ARG VERSION
-RUN (cd /trimmer && make && mv /trimmer/NSCtrim /usr/bin)
+RUN mkdir /trimmer
+WORKDIR /trimmer
+COPY NSCtrim.cpp .
+COPY bounded_levenshtein_distance.cpp .
+COPY Makefile .
+
+RUN make NSCtrim.static
+
+FROM alpine:3.13.5 AS RUNNER
+COPY --from=BUILDER /trimmer/NSCtrim.static /usr/bin/NSCtrim

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS += -O3 -std=c++11
 
 # If building locally, VERSION is not set by anything,
 # so this will set it to the current tag.
-# If using "build-docker.sh", use the environment variable
+# If using "docker-build.sh", use the environment variable
 # passed through docker.
 VERSION ?= $(shell git describe --tags --dirty )
 
@@ -14,6 +14,8 @@ NSCtrim: NSCtrim.cpp bounded_levenshtein_distance.cpp
 NSCtrim.static: NSCtrim.cpp bounded_levenshtein_distance.cpp
 	$(CXX) -o $@ NSCtrim.cpp -static $(CFLAGS) -lboost_program_options$(BOOST_LIB_SUFF) -lboost_iostreams$(BOOST_LIB_SUFF) -lz -DVERSION=\"${VERSION}\"
 
+docker:
+	docker build -t nsctrim:${VERSION} --build-arg VERSION="${VERSION}" .
 
 clean:
 	rm -f NSCtrim


### PR DESCRIPTION
Uses VERSION, and should make the
docker-build.sh obsolete