### PR TITLE
Fix: Use github.repository_owner instead of github.actor

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=ghcr.io/${{ github.actor }}/ncstrim
+          DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/ncstrim
           VERSION=latest
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
This should push the image to the correct location. Oversight from my side. In my case github.actor == github.repository_owner, but for your case, as you have an organisation, using the username of the person pushing the change would make no sense. I am not sure how to enable the feature preview on an organisational level, though.